### PR TITLE
Support DynamicImage in  canny and remove imperative .to_luma8() in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ many computer vision applications.
 
 ```rust
 let source_image = image::open("testdata/line-simple.png")
-    .expect("failed to read image")
-    .to_luma();
+    .expect("failed to read image");
+
 let detection = edge_detection::canny(
     source_image,
     1.2,  // sigma

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1,4 +1,4 @@
-use image::{self, GenericImageView};
+use image::{self, GenericImageView,DynamicImage, GrayImage};
 use rayon::prelude::*;
 use std::f32::consts::*;
 use std::*;
@@ -193,13 +193,14 @@ impl Edge {
 /// * If either `strong_threshold` or `weak_threshold` are outisde the range of 0 to 1 inclusive.
 /// * If `strong_threshold` is less than `weak_threshold`.
 /// * If `image` contains no pixels (either it's width or height is 0).
-pub fn canny<T: Into<image::GrayImage>>(
+pub fn canny<T: Into<DynamicImage>>(
     image: T,
     sigma: f32,
     strong_threshold: f32,
     weak_threshold: f32,
 ) -> Detection {
-    let gs_image = image.into();
+    let dyn_img: DynamicImage = image.into();
+    let gs_image: GrayImage    = dyn_img.into_luma8();
     assert!(gs_image.width() > 0);
     assert!(gs_image.height() > 0);
     let edges = detect_edges(&gs_image, sigma);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! ```
 //! let source_image = image::open("testdata/line-simple.png")
-//!     .expect("failed to read image")
-//!     .to_luma8();
+//!     .expect("failed to read image");
+//! 
 //! let detection = edge_detection::canny(
 //!     source_image,
 //!     1.2,  // sigma


### PR DESCRIPTION
## Problem

Calling the old `canny` signature as shown in the documentation example fails to compile because the trait bound could never be satisfied:

```text
error[E0277]: the trait bound `image::buffer_::ImageBuffer<image::color::Luma<u8>, Vec<u8>>:
    From<ImageBuffer<Luma<u8>, Vec<u8>>>` is not satisfied
   --> src\main.rs:7:9
    |
6   |     let detection = edge_detection::canny(
    |                     --------------------- required by a bound introduced by this call
7   |         source_image,
    |         ^^^^^^^^^^^^ the trait `From<ImageBuffer<Luma<u8>, Vec<u8>>>` is not implemented for `image::buffer_::ImageBuffer<image::color::Luma<u8>, Vec<u8>>`
    |
    = help: the trait `From<ImageBuffer<Luma<u8>, Vec<u8>>>` is not implemented for `image::buffer_::ImageBuffer<image::color::Luma<u8>, Vec<u8>>`
            but trait `From<image::dynimage::DynamicImage>` is implemented for it
    = help: for that trait implementation, expected `image::dynimage::DynamicImage`, found `ImageBuffer<Luma<u8>, Vec<u8>>`
    = note: required for `ImageBuffer<Luma<u8>, Vec<u8>>` to implement `Into<image::buffer_::ImageBuffer<image::color::Luma<u8>, Vec<u8>>>`

196 | pub fn canny<T: Into<image::GrayImage>>(
    |                 ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `canny`
```

## Changes
- **Signature update**  
  - Changed  
    ```diff
    - pub fn canny<T: Into<GrayImage>>(…)
    + pub fn canny<T: Into<DynamicImage>>(…)
    ```  
  - Internally convert to gray with  
    ```rust
    let dyn_img: DynamicImage = image.into();
    let gs_image: GrayImage    = dyn_img.into_luma8();
    ```
- **Documentation update**  
  - Removed the mandatory `.to_luma8()` call from the example in `lib.rs`.  
  - Removed the mandatory `.to_luma8()` call from the example in `README.md`

## Rationale
- The old bound `T: Into<GrayImage>` was never satisfied by any concrete type, leading to compilation errors, the example provided by the documentation simply didn't work.
- Accepting `Into<DynamicImage>` leverages existing `From<Buffer> for DynamicImage` implementations, allowing all common image buffers (RGB, RGBA, Luma, etc.) to be passed in.
- Conversion to 8‑bit grayscale remains unchanged internally, preserving the algorithm’s assumptions.

## Usage Examples
```rust
// 1) Explicit grayscale conversion:
let source_image = image::open("testdata/line-simple.png")
    .expect("failed to read image")
    .to_luma8();

let detection = edge_detection::canny(
    source_image,
    1.2,  // sigma
    0.2,  // strong threshold
    0.01, // weak threshold
);
```

```rust
// 2) Pass DynamicImage directly:
let source_image = image::open("testdata/line-simple.png")
    .expect("failed to read image");

let detection = edge_detection::canny(
    source_image,
    1.2,  // sigma
    0.2,  // strong threshold
    0.01, // weak threshold
);
 ```